### PR TITLE
COOKIE goal tracking on AJAX loaded elements

### DIFF
--- a/experiments/media/js/experiments.js
+++ b/experiments/media/js/experiments.js
@@ -9,11 +9,6 @@ experiments = function() {
     };
 }();
 
-$(function(){
-    $('[data-experiments-goal]').each(function() {
-        $(this).bind('click', function() {
-            $.cookie("experiments_goal", $(this).data('experiments-goal'), { path: '/' });
-        });
-    });
+$(document).delegate('[data-experiments-goal]', 'click', function() {
+    $.cookie("experiments_goal", $(this).data('experiments-goal'), { path: '/' });
 });
-


### PR DESCRIPTION
I don't think this changes the previous behaviour unless someone actively didn't want goal tracking on AJAX loaded elements.