### PR TITLE
Fix results table header not matching table contents

### DIFF
--- a/experiments/nexus_modules.py
+++ b/experiments/nexus_modules.py
@@ -138,6 +138,7 @@ class ExperimentsModule(nexus.NexusModule):
         alternatives = {}
         for alternative_name in experiment.alternatives.keys():
             alternatives[alternative_name] = experiment.participant_count(alternative_name)
+        alternatives = sorted(alternatives.items())
 
         control_participants = experiment.participant_count(CONTROL_GROUP)
 
@@ -182,7 +183,7 @@ class ExperimentsModule(nexus.NexusModule):
 
             results[goal] = {
                 "control": control,
-                "alternatives": alternatives_conversions,
+                "alternatives": sorted(alternatives_conversions.items()),
                 "relevant": goal in relevant_goals or relevant_goals == set([u'']),
                 "mwu" : goal in mwu_goals
             }

--- a/experiments/templates/nexus/experiments/results.html
+++ b/experiments/templates/nexus/experiments/results.html
@@ -76,7 +76,7 @@
             <tr>
                 <td class="goal odd"></td>
                 <td class="conversion1 even">control <small>({{ control_participants|intcomma }})</small></td>
-                {% for alternative, participants in alternatives.items %}
+                {% for alternative, participants in alternatives %}
                      {% if alternative != 'control' %}
                          <td colspan="3" class="conversion2 {% if forloop.counter|divisibleby:2 %}odd{% else %}even{% endif %}">{{ alternative }} <small>({{ participants|intcomma }})</small></td>
                      {% endif %}
@@ -99,7 +99,7 @@
                         {% endif %}
                         )</small></td>
 
-                    {% for alternative_name, results in data.alternatives.items %}
+                    {% for alternative_name, results in data.alternatives %}
                         {% if alternative_name != 'control' %}
                             <td class="conversion2 {% if forloop.counter|divisibleby:2 %}even{% else %}odd{% endif %}">
                                 {{ results.conversions|intcomma }}<small> ({{ results.conversion_rate|floatformat:2 }}%


### PR DESCRIPTION
Results table header and table contents are rendered from different dicts. By iterating the two dicts, alternatives may appear in different order, thus displaying one alternative's results under another alternative's title.
