### PR TITLE
Closest experiment goal

### DIFF
--- a/experiments/media/js/experiments.js
+++ b/experiments/media/js/experiments.js
@@ -4,7 +4,7 @@ experiments = function() {
             $.get("/experiments/confirm_human/");
         },
         goal: function(goal_name) {
-            $.post("/experiments/goal/" + goal_name);
+            $.post("/experiments/goal/" + goal_name + "/");
         }
     };
 }();
@@ -12,8 +12,9 @@ experiments = function() {
 if (document.addEventListener) {
     // sets the cookie in the capturing phase so that in the bubbling phase we guarantee that if a request is being issued it will contain the new cookie as well
     document.addEventListener("click", function(event) {
-        if ((event.target).hasAttribute('data-experiments-goal')) {
-            $.cookie("experiments_goal", $(event.target).data('experiments-goal'), { path: '/' });
+        closest = $(event.target).closest('[data-experiments-goal]')
+        if (closest.length) {
+            $.cookie("experiments_goal", $(closest[0]).data('experiments-goal'), { path: '/' });
         }
     }, true);
 } else { // IE 8


### PR DESCRIPTION
Use jquery `closest()` to determine whether the clicked element triggers experiment goal.

After introducing the addEventListener mechanism to set goals via cookie in the capturing phase of event handling in pull request https://github.com/mixcloud/django-experiments/pull/87, elements above the clicked element that have a `data-experiments-goal` attribute aren't reported as goals anymore, like in the bubbling event handling flow. 

This pull request uses jquery `closest()` to simulate this behavior and determine whether the current event target triggers an experiment goal on parent elements. If it does, it sets the cookie correspondingly.

Also, POSTing to the goal endpoint fails if the URL doesn't have the trailing slash.