### PR TITLE
EmployInsight's A/B testing contributions

### DIFF
--- a/example_project/templates/goal.html
+++ b/example_project/templates/goal.html
@@ -4,6 +4,14 @@
 <html>
 <head>
     <title>Goal Page</title>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js" type="text/javascript"></script>
+    <script src="{% url nexus:media 'experiments' 'js/jquery.cookie.js' %}"></script>
+    <script src="{% url nexus:media 'experiments' 'js/experiments.js' %}"></script>
+    <script type="text/javascript">
+            $(experiments).bind("goal-attained", function(event, goal) {
+                console.log("Goal, " + goal + ", attained!");
+            });
+    </script>
 </head>
 <body>
     {% experiment_goal "page_goal" %}

--- a/example_project/templates/test_page.html
+++ b/example_project/templates/test_page.html
@@ -8,6 +8,18 @@
     <script src="{% url 'nexus:media' 'experiments' 'js/jquery.cookie.js' %}"></script>
     <script src="{% url 'nexus:media' 'experiments' 'js/experiments.js' %}"></script>
 
+    <script type="text/javascript">
+        $(document).ready(function() {
+            $(experiments.enrollments).each(function(i, enrollment) {
+                $("#enrollments_list").append(
+                    $("<dt/>").text(enrollment.experiment)
+                ).append(
+                    $("<dd/>").text(enrollment.alternative)
+                );
+            });
+        });
+    </script>
+
     <script>
         jQuery(document).ajaxSend(function(event, xhr, settings) {
             function getCookie(name) {
@@ -61,6 +73,9 @@
 
     <span onclick="experiments.goal('js_goal')">JS GOAL</span>
     <span data-experiments-goal="cookie_goal">COOKIE GOAL</span>
+
+    <dl id="enrollments_list"></dl>
+    {% enrollments %}
 
     {% include "experiments/confirm_human.html" %}
 </body>

--- a/example_project/templates/test_page.html
+++ b/example_project/templates/test_page.html
@@ -10,6 +10,9 @@
 
     <script type="text/javascript">
         $(document).ready(function() {
+            $(experiments).bind("goal-attained", function(event, goal) {
+                console.log("Goal, " + goal + ", attained!");
+            });
             $(experiments.enrollments).each(function(i, enrollment) {
                 $("#enrollments_list").append(
                     $("<dt/>").text(enrollment.experiment)

--- a/example_project/templates/test_page.html
+++ b/example_project/templates/test_page.html
@@ -13,6 +13,9 @@
             $(experiments).bind("goal-attained", function(event, goal) {
                 console.log("Goal, " + goal + ", attained!");
             });
+
+            // Note: The enrollments array can only be accessed after
+            // $(document).ready.
             $(experiments.enrollments).each(function(i, enrollment) {
                 $("#enrollments_list").append(
                     $("<dt/>").text(enrollment.experiment)

--- a/experiments/media/js/experiments.js
+++ b/experiments/media/js/experiments.js
@@ -1,3 +1,9 @@
+// Subscribe to an event that triggers when the user attains a goal.
+// $(experiments).bind("goal-attained", function(event, goalName) {
+//     // do something (like send the goal attainment information to 
+//     // a third party service such as google analytics)
+// });
+
 experiments = function() {
     return {
         confirm_human: function() {
@@ -5,6 +11,10 @@ experiments = function() {
         },
         goal: function(goal_name) {
             $.post("/experiments/goal/" + goal_name);
+
+            // Trigger the experiments 'goal' event so others
+            // can do something in reaction to goal attainment.
+            $(experiments).trigger('goal-attained', [goal_name]);
         }
     };
 }();
@@ -14,11 +24,28 @@ if (document.addEventListener) {
     document.addEventListener("click", function(event) {
         if ((event.target).hasAttribute('data-experiments-goal')) {
             $.cookie("experiments_goal", $(event.target).data('experiments-goal'), { path: '/' });
+
+            // Trigger the experiments 'goal' event so others
+            // can do something in reaction to goal attainment.
+            $(experiments).trigger('goal-attained', [goal_name]);
         }
     }, true);
 } else { // IE 8
     $(document).delegate('[data-experiments-goal]', 'click', function(e) {
         // if a request is fired by the click event, the cookie might get set after it, thus the goal will be recorded with the next request (if there will be one)
         $.cookie("experiments_goal", $(this).data('experiments-goal'), { path: '/' });
+
+            // Trigger the experiments 'goal' event so others
+            // can do something in reaction to goal attainment.
+            $(experiments).trigger('goal-attained', [goal_name]);
     });
 }
+
+$(function() {
+    $(".experiments-goal").each(function() {
+
+        // Trigger the experiments 'goal-attained' event so others
+        // can do something in reaction to template-tag goal attainment.
+        $(experiments).trigger('goal-attained', [$(this).data("experiments-goal-name")]);
+    });
+});

--- a/experiments/media/js/experiments.js
+++ b/experiments/media/js/experiments.js
@@ -13,7 +13,7 @@ experiments = function() {
             $.get("/experiments/confirm_human/");
         },
         goal: function(goal_name) {
-            $.post("/experiments/goal/" + goal_name);
+            $.post("/experiments/goal/" + goal_name + "/");
 
             // Trigger the experiments 'goal' event so others
             // can do something in reaction to goal attainment

--- a/experiments/media/js/experiments.js
+++ b/experiments/media/js/experiments.js
@@ -1,4 +1,7 @@
+// EXAMPLE:
+//
 // Subscribe to an event that triggers when the user attains a goal.
+//
 // $(experiments).bind("goal-attained", function(event, goalName) {
 //     // do something (like send the goal attainment information to 
 //     // a third party service such as google analytics)
@@ -13,7 +16,8 @@ experiments = function() {
             $.post("/experiments/goal/" + goal_name);
 
             // Trigger the experiments 'goal' event so others
-            // can do something in reaction to goal attainment.
+            // can do something in reaction to goal attainment
+            // called from javascript-initiated goal.
             $(experiments).trigger('goal-attained', [goal_name]);
         }
     };
@@ -26,7 +30,8 @@ if (document.addEventListener) {
             $.cookie("experiments_goal", $(event.target).data('experiments-goal'), { path: '/' });
 
             // Trigger the experiments 'goal' event so others
-            // can do something in reaction to goal attainment.
+            // can do something in reaction to goal attainment
+            // from a cookie-initiated goal.
             $(experiments).trigger('goal-attained', [goal_name]);
         }
     }, true);
@@ -36,7 +41,8 @@ if (document.addEventListener) {
         $.cookie("experiments_goal", $(this).data('experiments-goal'), { path: '/' });
 
             // Trigger the experiments 'goal' event so others
-            // can do something in reaction to goal attainment.
+            // can do something in reaction to goal attainment
+            // from a click-initiated goal.
             $(experiments).trigger('goal-attained', [goal_name]);
     });
 }
@@ -46,6 +52,9 @@ $(function() {
 
         // Trigger the experiments 'goal-attained' event so others
         // can do something in reaction to template-tag goal attainment.
+        // The class '.experiments-goal' and the data attribute
+        // 'experiments-goal-name' are included in the img file returned
+        // by the server upon successful goal attainment.
         $(experiments).trigger('goal-attained', [$(this).data("experiments-goal-name")]);
     });
 });

--- a/experiments/middleware.py
+++ b/experiments/middleware.py
@@ -13,6 +13,17 @@ class ExperimentsMiddleware(object):
             response.delete_cookie('experiments_goal')
         return response
 
+    def process_request(self, request):
+        """
+        Allows setting of experiment and alternative via URL Params.
+        """
+        experiment = request.GET.get('exp', '')
+        alternative = request.GET.get('alt', 'control')
+        if experiment is not '':
+            request.session['experiment'] = experiment
+            request.session['alternative'] = alternative
+        return None
+
 class CSRFMiddleware(object):
     def process_request(self, request):
         # Forces process_response to set the CSRF cookie for POSTing

--- a/experiments/middleware.py
+++ b/experiments/middleware.py
@@ -1,5 +1,7 @@
 from experiments import record_goal
 
+from django.middleware.csrf import get_token
+
 from urllib import unquote
 
 class ExperimentsMiddleware(object):
@@ -10,3 +12,10 @@ class ExperimentsMiddleware(object):
                 record_goal(goal, request)
             response.delete_cookie('experiments_goal')
         return response
+
+class CSRFMiddleware(object):
+    def process_request(self, request):
+        # Forces process_response to set the CSRF cookie for POSTing
+        # experiment goals to server.
+        get_token(request)
+        return None

--- a/experiments/templates/experiments/enrollments.html
+++ b/experiments/templates/experiments/enrollments.html
@@ -1,0 +1,3 @@
+<script type="text/javascript" charset="utf-8">
+    experiments.enrollments = {{ experiment_enrollments }};
+</script>

--- a/experiments/templates/experiments/goal.html
+++ b/experiments/templates/experiments/goal.html
@@ -1,1 +1,1 @@
-<img src="{{ url }}" height="1" width="1" />
+<img class="experiments-goal" data-experiments-goal-name="{{ goal_name }}" src="{{ url }}" height="1" width="1" />

--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -34,8 +34,15 @@ class ExperimentNode(template.Node):
             user = participant(request)
             gargoyle_key = request
 
+        # Extract session alternative, if any pertain to this experiment.
+        selected_alternative = None
+        if 'experiment' in request.session:
+            if request.session['experiment'] == self.experiment_name:
+                selected_alternative = request.session['alternative']
+                del request.session['experiment']
+
         # Should we render?
-        if user.is_enrolled(self.experiment_name, self.alternative, gargoyle_key):
+        if user.is_enrolled(self.experiment_name, self.alternative, gargoyle_key, selected_alternative):
             response = self.node_list.render(context)
         else:
             response = ""
@@ -103,10 +110,16 @@ def visit(context):
 def enrollments(context):
     """
     Adds an array named 'enrollments' to the experiments javascript
-    variable.  This array of name, alternative object literals describes
-    each running experiment and the alternative selected for the user.
+    variable.  This array of 
+
+    [{'experiment': experiment_name, 'alternative': alternative_name}, ...]
+
+    describes each running experiment and the alternative selected for the user.
     Other template tags may select experiments and alternatives so use this
     tag after all of the other experiments template tags in your template.
+
+    Note: The enrollments array can only be accessed after
+    $(document).ready.
     """
     request = context.get('request', None)
     user = participant(request)

--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -13,7 +13,8 @@ register = template.Library()
 
 @register.inclusion_tag('experiments/goal.html')
 def experiment_goal(goal_name):
-    return { 'url': reverse('experiment_goal', kwargs={'goal_name': goal_name, 'cache_buster': uuid4()}) }
+    return {'url': reverse('experiment_goal', kwargs={'goal_name': goal_name, 'cache_buster': uuid4()}),
+            'goal_name': goal_name}
 
 class ExperimentNode(template.Node):
     def __init__(self, node_list, experiment_name, alternative, user_variable):

--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
+from json import dumps as to_json
 
 from django import template
 from django.core.urlresolvers import reverse
+from django.utils.safestring import mark_safe
 
 from experiments.utils import participant
 from experiments.manager import experiment_manager
@@ -95,3 +97,19 @@ def visit(context):
     request = context.get('request', None)
     participant(request).visit()
     return ""
+
+@register.inclusion_tag('experiments/enrollments.html', takes_context=True)
+def enrollments(context):
+    """
+    Adds an array named 'enrollments' to the experiments javascript
+    variable.  This array of name, alternative object literals describes
+    each running experiment and the alternative selected for the user.
+    Other template tags may select experiments and alternatives so use this
+    tag after all of the other experiments template tags in your template.
+    """
+    request = context.get('request', None)
+    user = participant(request)
+    enrollments = [{'experiment': enrollment.experiment.name,
+                    'alternative': enrollment.alternative}
+                    for enrollment in user._get_all_enrollments()]
+    return {'experiment_enrollments': mark_safe(to_json(enrollments))}

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -61,7 +61,7 @@ class WebUser(object):
         """Enroll this user in the experiment if they are not already part of it. Returns the selected alternative"""
         chosen_alternative = conf.CONTROL_GROUP
 
-        experiment = experiment_manager.get(experiment_name, None)
+        experiment = experiment_manager[experiment_name]
         if experiment and experiment.is_displaying_alternatives():
             if isinstance(alternatives, collections.Mapping):
                 if conf.CONTROL_GROUP not in alternatives:


### PR DESCRIPTION
1. Add CSRF Middleware
  * **What it does:** ensures CSRF token included on every response from server.
  * **Why:** Since goal attainment in django-experiments uses a POST, we needed a CSRF token included with every response from the server so the goal POST doesn't fail.
2. Add enrollments
  * **What it does:** gets all the current users' enrollments and creates a javascript variable, experiments.enrollments, which is an array of the current users' experiments and alternatives.
  * **Why:** Helpful for writing client-side scripts. We made use of it in our codebase to instantiate different Backbone views based on the users enrollments.
3. Trigger javascript goal
  * **What it does:** every time the django-experiments framework obtains a goal (this can happen many ways - through a POST to server which returns a 1x1 image, cookie which contains a goal, or click triggered goal), trigger an event (namely 'goal-attained') on the experiments variable, so that we can listen to that event client-side and perform something.
  * **Why:** We use this to run javascript on goal attainment, e.g. sending the event to Google Analytics or Optimizely.
4. Bucket user via URL params
  * **What it does:** create a url with the params **exp=[experiment]&alt=[alternative]** and django-experiments will bucket the user into that alternative _**if the user isn't already assigned an alternative**_.
  * **Why:** We found it useful to be able to trigger an alternative via URL for bucketing in our ad-campaigns.

_**mixcloud**, we've been using your django-experiments framework extensively here at **EmployInsight**. We’ve found these additions to add helpful hooks for integrating into existing tools and writing intelligent, experiment-aware client-side code. Let us know your thoughts! It would be great to get these features into django-experiments._