### PR TITLE
use django-jsonfield instead of jsonfield

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis>=2.4.9
 django>=1.3.0
 nexus>=0.2.3
-jsonfield>=0.9
+django-jsonfield>=0.8.0,<0.9.4
 gargoyle>=0.9.0


### PR DESCRIPTION
django-jsonfield and jsonfield are two different projects that use the same namespace (`from jsonfield import JSONField`).

https://pypi.python.org/pypi/jsonfield/0.9.22
https://pypi.python.org/pypi/django-jsonfield/0.9.13

Gargoyle uses django-jsonfield and django-experiements uses jsonfield, resulting in both being installed and one of the requirements overwriting the namespace of the other.

This commit matches the django-jsonfield requirement with Gargoyle. Another solution would be to remove the requirement entirely, as it's now provided by Gargoyle.