### PR TITLE
fix example project

### DIFF
--- a/example_project/manage.py
+++ b/example_project/manage.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
+import os
+import sys
 
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+from django.conf import settings
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -114,7 +114,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'experiments.middleware.ExperimentsMiddleware',
+    'experiments.middleware.ExperimentsRetentionMiddleware',
 )
 
 ROOT_URLCONF = 'example_project.urls'


### PR DESCRIPTION
The included example project doesn't work on >=Django 1.6 as manage.py is changed.

This PR fixes it.