### PR TITLE
removed django-jsonfield==0.9.13 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 redis>=2.4.9
 django>=1.7.0
-django-jsonfield==0.9.13
 django-modeldict==1.4.1
 mock==1.0.1


### PR DESCRIPTION
Two reasons for this pull request:

1) django-jsonfield generated a conflict with our already installed jsonfield so I had to modify requirements.txt

2) The following pull https://github.com/mixcloud/django-experiments/pull/120 indicates it is no longer needed for the repository.