### PR TITLE
Fixes bug in the 'goals' example in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -304,7 +304,7 @@ Add the goal to our EXPERIMENT_GOALS tuple in setting.py:
 
 ::
 
-    EXPERIMENTS_GOALS = ("registration")
+    EXPERIMENTS_GOALS = ("registration",)
 
 Goals are simple strings that uniquely identify a goal. 
 


### PR DESCRIPTION
The current example for adding a goal in the README does not give a
tuple. Python will evaluate the example as a single string and will iterate over
the string, creating a new goal for each letter. Adding a comma after
the string turns it into a tuple which means that only one goal will be
created.

Fixes #146.