### PR TITLE
Add backwards compatible python3 support

### DIFF
--- a/experiments/manager.py
+++ b/experiments/manager.py
@@ -7,9 +7,11 @@ class LazyAutoCreate(object):
     """
     A lazy version of the setting is used so that tests can change the setting and still work
     """
-    def __nonzero__(self):
+    def __bool__(self):
         return getattr(settings, 'EXPERIMENTS_AUTO_CREATE', True)
 
+    def __nonzero__(self):
+        return type(self).__bool__(self)
 
 class ExperimentManager(ModelDict):
     def get_experiment(self, experiment_name):

--- a/experiments/models.py
+++ b/experiments/models.py
@@ -6,6 +6,7 @@ from jsonfield import JSONField
 
 import random
 import json
+from six import iteritems
 
 from experiments.dateutils import now
 from experiments import conf
@@ -65,13 +66,13 @@ class Experiment(models.Model):
 
     @property
     def default_alternative(self):
-        for alternative, alternative_conf in self.alternatives.iteritems():
+        for alternative, alternative_conf in iteritems(self.alternatives):
             if alternative_conf.get('default'):
                 return alternative
         return conf.CONTROL_GROUP
 
     def set_default_alternative(self, alternative):
-        for alternative_name, alternative_conf in self.alternatives.iteritems():
+        for alternative_name, alternative_conf in iteritems(self.alternatives):
             if alternative_name == alternative:
                 alternative_conf['default'] = True
             elif 'default' in alternative_conf:
@@ -79,9 +80,9 @@ class Experiment(models.Model):
 
     def random_alternative(self):
         if all('weight' in alt for alt in self.alternatives.values()):
-            return weighted_choice([(name, details['weight']) for name, details in self.alternatives.items()])
+            return weighted_choice([(name, details['weight']) for name, details in iteritems(self.alternatives)])
         else:
-            return random.choice(self.alternatives.keys())
+            return random.choice(list(self.alternatives))
 
     def __unicode__(self):
         return self.name
@@ -127,5 +128,3 @@ def weighted_choice(choices):
         upto += w
         if upto >= r:
             return c
-
-

--- a/experiments/significance.py
+++ b/experiments/significance.py
@@ -5,7 +5,7 @@ def mann_whitney(a_distribution, b_distribution, use_continuity=True):
     """Returns (u, p_value)"""
     MINIMUM_VALUES = 20
 
-    all_values = sorted(set(a_distribution.keys() + b_distribution.keys()))
+    all_values = sorted(set(list(a_distribution) + list(b_distribution)))
 
     count_so_far = 0
     a_rank_sum = 0

--- a/experiments/tests/test_admin.py
+++ b/experiments/tests/test_admin.py
@@ -4,6 +4,7 @@ import json
 from django.contrib.auth.models import User, Permission
 from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.utils import six
 
 from experiments.models import Experiment, CONTROL_STATE, ENABLED_STATE
 from experiments.utils import participant
@@ -44,7 +45,11 @@ class AdminTestCase(TestCase):
                 'experiment': experiment.name,
                 'alternative': alternative,
             })
-            self.assertDictEqual(json.loads(response.content), {
+            response_content = response.content
+            if six.PY3:
+                response_content = str(response_content, encoding='utf8')
+
+            self.assertDictEqual(json.loads(response_content), {
                 'success': True,
                 'alternative': alternative,
             })

--- a/experiments/tests/test_significance.py
+++ b/experiments/tests/test_significance.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import random
+from django.utils.six.moves import range
 
 from experiments.significance import mann_whitney, chi_square_p_value
 
@@ -52,9 +53,9 @@ class ChiSquare(TestCase):
     def test_stress(self):
         # Generate a large matrix
         matrix = []
-        for col in xrange(0, 100):
+        for col in range(0, 100):
             matrix.append([])
-            for row in xrange(0, 100):
+            for row in range(0, 100):
                 matrix[col].append(random.randint(0, 10))
 
         self.assertIsNotNone(chi_square_p_value(matrix))
@@ -72,4 +73,3 @@ class ChiSquare(TestCase):
         observed_test_statistic_result, p_value_result = chi_square_p_value(matrix)
         self.assertAlmostEqual(observed_test_statistic_result, observed_test_statistic, accuracy, 'Wrong observed result')
         self.assertAlmostEqual(p_value_result, p_value, accuracy, 'Wrong P Value')
-

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -400,7 +400,7 @@ class SessionUser(WebUser):
     def _get_all_enrollments(self):
         enrollments = self.session.get('experiments_enrollments', None)
         if enrollments:
-            for experiment_name, data in enrollments.items():
+            for experiment_name, data in list(enrollments.items()):
                 alternative, _, enrollment_date, last_seen = _session_enrollment_latest_version(data)
                 experiment = experiment_manager.get_experiment(experiment_name)
                 if experiment:


### PR DESCRIPTION
Theses changes get the project running with python2 and python3(#143).  Unfortunately I am unable to run the tests from a clean checkout/environment with python2 without any failures so cannot confirm that it works perfectly. That being said, none of the tests have started failing due to the changes. 
