### PR TITLE
Minimal install requires

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE README.rst requirements.txt
+include LICENSE README.rst
 recursive-include experiments *.py *.html *.js *.css *.png *.jpg

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ pip is still the recommended way to install dependencies:
 
 ::
 
-    pip install -r requirements.txt
+    pip install -e .
 
 Dependencies
 ------------
@@ -35,7 +35,7 @@ Dependencies
 - `jsonfield <https://github.com/bradjasper/django-jsonfield/>`_
 - `django-modeldict <https://github.com/disqus/django-modeldict>`_
 
-(Detailed list in requirements.txt)
+(Detailed list in setup.py)
 
 It also requires 'django.contrib.humanize' to be in INSTALLED_APPS.
 
@@ -340,6 +340,18 @@ See conf.py for other settings
 
 Changelog
 ---------
+UNRELEASED
+~~~~~~~~~~
+ - Conform to common expectations in `setup.py`:
+    - Separate `install_requires` and `tests_require` (not reading from `requirements.txt`)
+    - Add trove classifiers including Python and Django supported versions
+    - Fix license name (from "MIT license, see LICENSE file" to "MIT")
+    - Make `setup.py` ready for Python 3 (read `README.rst` using codecs module)
+    - Dropped an irrelevant workaround for ancient Python bugs
+ - Add `setup.cfg` to support building of universal wheels (preparing for Python 3)
+ - Tox runs `python setup.py test` (honouring both `install_requires` and `tests_require`)
+ - Prepared `tox.ini` for Python 3 and Django 1.11 compatibility
+
 1.2.0
 ~~~~~
  - Add support for Django 1.10 (Thanks to @Kobold)
@@ -384,6 +396,7 @@ Changelog
 
 Bumping version to 1.0.0 because django-experiments is definitely production
 ready but also due to backwards incompatible changes that have been merged in.
+
  - Django 1.7 and 1.8 support (including custom user models)
  - Fixed numerous bugs to do with retention goals - before this update they are not trustworthy. See retention section below for more information.
  - Fixed bug caused by the participant cache on request

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-redis>=2.4.9
-django>=1.7.0
-django-modeldict-yplan>=1.5.0
-jsonfield>=1.0.3
-mock>=1.0.1
-tox>=2.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,48 @@
-from distutils.core import setup
-from setuptools import find_packages
-import re
-
-# http://bugs.python.org/issue15881
-try:
-    import multiprocessing
-except ImportError:
-    pass
+import codecs  # to use a consistent encoding
+from os import path
+from setuptools import setup, find_packages  # prefer setuptools over distutils
 
 
-def parse_requirements(file_name):
-    requirements = []
-    for line in open(file_name, 'r').read().split('\n'):
-        if re.match(r'(\s*#)|(\s*$)', line):
-            continue
-        if re.match(r'\s*-e\s+', line):
-            requirements.append(re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1', line))
-        elif re.match(r'\s*-f\s+', line):
-            pass
-        else:
-            requirements.append(line)
+# Get the long description from the README file
+PATH = path.abspath(path.dirname(__file__))
+with codecs.open(path.join(PATH, 'README.rst'), encoding='utf-8') as f:
+    LONG_DESCRIPTION = f.read()
 
-    return requirements
-
-
-def parse_dependency_links(file_name):
-    dependency_links = []
-    for line in open(file_name, 'r').read().split('\n'):
-        if re.match(r'\s*-[ef]\s+', line):
-            dependency_links.append(re.sub(r'\s*-[ef]\s+', '', line))
-
-    return dependency_links
-
-
-setup(name='django-experiments',
-      version='1.2.0',
-      description='Python Django AB Testing Framework',
-      author='Mixcloud',
-      author_email='technical@mixcloud.com',
-      url='https://github.com/mixcloud/django-experiments',
-      packages=find_packages(exclude=["example_project"]),
-      include_package_data=True,
-      license="MIT license, see LICENSE file",
-      install_requires=parse_requirements('requirements.txt'),
-      dependency_links=parse_dependency_links('requirements.txt'),
-      long_description=open('README.rst').read(),
-      test_suite="testrunner.runtests",
+setup(
+    name='django-experiments',
+    version='1.2.0',
+    description='Python Django AB Testing Framework',
+    long_description=LONG_DESCRIPTION,
+    author='Mixcloud',
+    author_email='technical@mixcloud.com',
+    url='https://github.com/mixcloud/django-experiments',
+    packages=find_packages(exclude=["example_project"]),
+    include_package_data=True,
+    license='MIT',
+    install_requires=[
+        'django>=1.7.0',
+        'django-modeldict-yplan>=1.5.0',
+        'jsonfield>=1.0.3',
+        'redis>=2.4.9',
+    ],
+    tests_require=[
+        'mock>=1.0.1',
+        'tox>=2.3.1',
+    ],
+    test_suite="testrunner.runtests",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Software Development :: Libraries',
+        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Framework :: Django',
+        'Framework :: Django :: 1.7',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,6 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,16 @@
 [tox]
-envlist = py27-django{17,18,19,110}
+# Django 1.11 and Python 3 aren't supported yet
+envlist =
+    py27-django{18,19,110}
+#    py32-django{18}
+#    py33-django{18}
+#    py{34,35}-django{19,110,111}
+#    py{36}-django{111}
 
 [testenv]
-commands = python testrunner.py
+commands = python setup.py test
 deps =
-    django17: Django < 1.8
-    django18: Django < 1.9
-    django19: Django < 1.10
-    django110: Django < 1.11
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Django 1.11 and Python 3 aren't supported yet
 envlist =
-    py27-django{18,19,110}
+    py27-django{18,19,110,111}
 #    py32-django{18}
 #    py33-django{18}
 #    py{34,35}-django{19,110,111}


### PR DESCRIPTION
Remove unnecessary installation requirements (issue #152), prepares for Python 3 (PR #157).

Updated Changelog with the following:
 - Conform to common expectations in `setup.py`:
    - Separate `install_requires` and `tests_require` (not reading from `requirements.txt`)
    - Add trove classifiers including Python and Django supported versions
    - Fix license name (from "MIT license, see LICENSE file" to "MIT")
    - Make `setup.py` ready for Python 3 (read `README.rst` using codecs module)
    - Dropped an irrelevant workaround for ancient Python bugs
 - Add `setup.cfg` to support building of universal wheels (preparing for Python 3)
 - Tox runs `python setup.py test` (honouring both `install_requires` and `tests_require`)
 - Prepared `tox.ini` for Python 3 and Django 1.11 compatibility