### PR TITLE
Fixed AttributeError when using experiments template tags in your base template

### DIFF
--- a/experiments/templatetags/experiments.py
+++ b/experiments/templatetags/experiments.py
@@ -20,7 +20,8 @@ def experiment_goal(goal_name):
 @register.inclusion_tag('experiments/confirm_human.html', takes_context=True)
 def experiments_confirm_human(context):
     request = context.get('request')
-    return {'confirmed_human': request.session.get(conf.CONFIRM_HUMAN_SESSION_KEY, False)}
+    if request:
+        return {'confirmed_human': request.session.get(conf.CONFIRM_HUMAN_SESSION_KEY, False)}
 
 
 class ExperimentNode(template.Node):


### PR DESCRIPTION
I use `{% experiments_confirm_human %}` in my `base.html` template, which is also used for Django error pages. This causes the web process to die with an ugly 500 page instead of the pretty Django one when an error occurs.

Example traceback:

```
File "..../site-packages/experiments/templatetags/experiments.py", line 23, in experiments_confirm_human
return {'confirmed_human': request.session.get(conf.CONFIRM_HUMAN_SESSION_KEY, False)}
AttributeError: 'NoneType' object has no attribute 'session'
```

The template tag should probably not be used on error pages in the first place, but we can prevent it from failing by checking if the request is None.