### PR TITLE
Limit major version of django-modeldict-yplan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license='MIT',
     install_requires=[
         'django>=1.8',
-        'django-modeldict-yplan>=1.5.0',
+        'django-modeldict-yplan>=1.5.0,<2.0.0',
         'jsonfield>=1.0.3',
         'redis>=2.4.9',
     ],


### PR DESCRIPTION
This PR sets an upper limit to the version of `django-modeldict-yplan` that `django-experiments` attempts to install as a dependency.

* `django-modeldict-yplan` has released version 2.0.0, which [only supports python>=3.4](https://pypi.org/project/django-modeldict-yplan/).
* Users with Python2 who attempt to install `django-experiments` with `pip` will pull in `django-modeldict-yplan==2.0.0`, but the installation fails:
```
Collecting django-modeldict-yplan>=1.5.0 (from django-experiments->-r requirements/base.txt (line 40))
  Downloading https://files.pythonhosted.org/packages/a6/0e/ef6d576ea0c2c606fd70e92e25c129f7715d3be1b45a14f3e2f79ae99858/django-modeldict-yplan-2.0.0.tar.gz
django-modeldict-yplan requires Python '>=3.4' but the running Python is 2.7.15
Exited with code 1
```

Closes mixcloud/django-experiments#183